### PR TITLE
Signature 2.0

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -168,7 +168,7 @@ A simple example program is provided in `test.go`:
 
 ```bash
 cd go
-go run ./test.go
+go run ./example_test.go
 ```
 
 ## License

--- a/go/constants.go
+++ b/go/constants.go
@@ -11,8 +11,8 @@ const (
 const GonkaChainID = "gonka-testnet-3"
 
 // Default endpoints if none are provided
-var DefaultEndpoints = []string{
-	"https://api.gonka.testnet.example.com",
-	"https://api2.gonka.testnet.example.com",
-	"https://api3.gonka.testnet.example.com",
+var DefaultEndpoints = []Endpoint{
+	{URL: "https://api.gonka.testnet.example.com", Address: "transfer_address_1"},
+	{URL: "https://api2.gonka.testnet.example.com", Address: "transfer_address_2"},
+	{URL: "https://api3.gonka.testnet.example.com", Address: "transfer_address_3"},
 }

--- a/go/example_test.go
+++ b/go/example_test.go
@@ -24,12 +24,27 @@ func TestExampleUsage(t *testing.T) {
 	}
 
 	t.Log("\n------ Test Environment ------") // Use t.Log for test output
-	baseURL := gonkaopenai.GonkaBaseURL(nil)
+
+	// Create a list of endpoints with their transfer addresses
+	// In a real application, these would be loaded from configuration or environment variables
+	endpoints := []gonkaopenai.Endpoint{
+		{URL: "https://api.gonka.testnet.example.com", Address: "transfer_address_1"},
+		{URL: "https://api2.gonka.testnet.example.com", Address: "transfer_address_2"},
+		{URL: "https://api3.gonka.testnet.example.com", Address: "transfer_address_3"},
+	}
+
+	// Get a random endpoint URL for the base URL
+	baseURL := gonkaopenai.GonkaBaseURL(endpoints)
 	t.Log("Using Gonka Base URL:", baseURL)
 
-	// The APIKey is often a mock or test-specific key in test environments
+	t.Log("Using endpoints with transfer addresses:")
+	for _, endpoint := range endpoints {
+		t.Logf("  %s -> %s", endpoint.URL, endpoint.Address)
+	}
+
 	client, err := gonkaopenai.NewGonkaOpenAI(gonkaopenai.Options{
 		GonkaPrivateKey: os.Getenv(gonkaopenai.EnvPrivateKey),
+		Endpoints:       endpoints,
 	})
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err) // Use t.Fatalf to fail the test on critical errors
@@ -89,16 +104,30 @@ func TestDirectOpenAIUsage(t *testing.T) {
 		t.Log("Warning: GonkaAddress could not be determined. GonkaHTTPClient might fail or use defaults.")
 	}
 
-	// 3. Get Gonka Base URL
-	baseURL := gonkaopenai.GonkaBaseURL(nil) // Assuming no specific endpoints for this test
+	// 3. Create a list of endpoints with their transfer addresses
+	// In a real application, these would be loaded from configuration or environment variables
+	endpoints := []gonkaopenai.Endpoint{
+		{URL: "https://api.gonka.testnet.example.com", Address: "transfer_address_1"},
+		{URL: "https://api2.gonka.testnet.example.com", Address: "transfer_address_2"},
+		{URL: "https://api3.gonka.testnet.example.com", Address: "transfer_address_3"},
+	}
+
+	// Get a random endpoint URL for the base URL
+	baseURL := gonkaopenai.GonkaBaseURL(endpoints)
 	t.Log("Using Gonka Base URL for manual client:", baseURL)
 	t.Log("Using Gonka Private Key (for HTTP client):", gonkaPrivateKey[:5]+"...") // Log a snippet for verification
 	t.Log("Using Gonka Address (for HTTP client):", gonkaAddress)
 
-	// 4. Create Gonka HTTP Client
+	t.Log("Using endpoints with transfer addresses:")
+	for _, endpoint := range endpoints {
+		t.Logf("  %s -> %s", endpoint.URL, endpoint.Address)
+	}
+
+	// 4. Create Gonka HTTP Client with endpoints
 	customHTTPClient := gonkaopenai.GonkaHTTPClient(gonkaopenai.HTTPClientOptions{
 		PrivateKey: gonkaPrivateKey,
 		Address:    gonkaAddress,
+		Endpoints:  endpoints,
 		Client:     nil, // No base client override for this test
 	})
 	t.Log("Custom Gonka HTTP Client configured.")

--- a/go/example_test.go
+++ b/go/example_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
+var defaultModel = "Qwen/QwQ-32B" // Default model for testing
 func TestExampleUsage(t *testing.T) {
 	err := godotenv.Load()
 	if err != nil {
@@ -27,11 +28,12 @@ func TestExampleUsage(t *testing.T) {
 
 	// Create a list of endpoints with their transfer addresses
 	// In a real application, these would be loaded from configuration or environment variables
-	endpoints := []gonkaopenai.Endpoint{
-		{URL: "https://api.gonka.testnet.example.com", Address: "transfer_address_1"},
-		{URL: "https://api2.gonka.testnet.example.com", Address: "transfer_address_2"},
-		{URL: "https://api3.gonka.testnet.example.com", Address: "transfer_address_3"},
-	}
+	//endpoints := []gonkaopenai.Endpoint{
+	//	{URL: "https://api.gonka.testnet.example.com", Address: "transfer_address_1"},
+	//	{URL: "https://api2.gonka.testnet.example.com", Address: "transfer_address_2"},
+	//	{URL: "https://api3.gonka.testnet.example.com", Address: "transfer_address_3"},
+	//}
+	endpoints := gonkaopenai.GetEndpointsFromEnv()
 
 	// Get a random endpoint URL for the base URL
 	baseURL := gonkaopenai.GonkaBaseURL(endpoints)
@@ -53,7 +55,7 @@ func TestExampleUsage(t *testing.T) {
 
 	t.Log("\nSending request...")
 	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-		Model: "Qwen/QwQ-32B", // Model as a string, consistent with gonkaopenai.go
+		Model: defaultModel, // Model as a string, consistent with gonkaopenai.go
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage("Hello! Tell me a short joke for a test."), // Using UserMessage helper
 		},
@@ -106,11 +108,12 @@ func TestDirectOpenAIUsage(t *testing.T) {
 
 	// 3. Create a list of endpoints with their transfer addresses
 	// In a real application, these would be loaded from configuration or environment variables
-	endpoints := []gonkaopenai.Endpoint{
-		{URL: "https://api.gonka.testnet.example.com", Address: "transfer_address_1"},
-		{URL: "https://api2.gonka.testnet.example.com", Address: "transfer_address_2"},
-		{URL: "https://api3.gonka.testnet.example.com", Address: "transfer_address_3"},
-	}
+	//endpoints := []gonkaopenai.Endpoint{
+	//	{URL: "https://api.gonka.testnet.example.com", Address: "transfer_address_1"},
+	//	{URL: "https://api2.gonka.testnet.example.com", Address: "transfer_address_2"},
+	//	{URL: "https://api3.gonka.testnet.example.com", Address: "transfer_address_3"},
+	//}
+	endpoints := gonkaopenai.GetEndpointsFromEnv()
 
 	// Get a random endpoint URL for the base URL
 	baseURL := gonkaopenai.GonkaBaseURL(endpoints)
@@ -146,7 +149,7 @@ func TestDirectOpenAIUsage(t *testing.T) {
 
 	t.Log("Sending request with manually configured Gonka-like client...")
 	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-		Model: "Qwen/QwQ-32B", // Using the same model as TestExampleUsage
+		Model: defaultModel, // Using the same model as TestExampleUsage
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage("Hello Gonka-configured client! Tell me a very short story."),
 		},

--- a/python/src/constants.py
+++ b/python/src/constants.py
@@ -14,8 +14,9 @@ class ENV:
 GONKA_CHAIN_ID = "gonka-testnet-1"
 
 # Default endpoints to use if none are provided
+# Format: "url;address" - the part after the semicolon is the transfer address
 DEFAULT_ENDPOINTS = [
-    "https://api.gonka.testnet.example.com",
-    "https://api2.gonka.testnet.example.com",
-    "https://api3.gonka.testnet.example.com",
+    "https://api.gonka.testnet.example.com;gonka1default",
+    "https://api2.gonka.testnet.example.com;gonka1default",
+    "https://api3.gonka.testnet.example.com;gonka1default",
 ] 

--- a/python/src/utils.py
+++ b/python/src/utils.py
@@ -8,7 +8,26 @@ import random
 import hashlib
 import base64
 import logging
-from typing import Any, Callable, Dict, List, Optional, Union, Tuple
+import time
+from typing import Any, Callable, Dict, List, Optional, Union, Tuple, NamedTuple
+from dataclasses import dataclass
+
+# Initialize base values for hybrid timestamp generation
+_wall_base = time.time_ns()
+_perf_base = time.perf_counter_ns()
+
+def hybrid_timestamp_ns():
+    """
+    Generate a hybrid timestamp in nanoseconds that combines wall clock time with a performance counter.
+    
+    This approach ensures:
+    1. Timestamps are unique and monotonically increasing (never go backwards)
+    2. Timestamps remain accurate to standard time servers (assuming system wall time is accurate)
+    
+    Returns:
+        A unique timestamp in nanoseconds
+    """
+    return _wall_base + (time.perf_counter_ns() - _perf_base)
 
 # Import necessary libraries for OpenAI client
 from openai import DefaultHttpxClient
@@ -23,11 +42,42 @@ from ecdsa import SigningKey, SECP256k1, util
 
 from .constants import ENV, DEFAULT_ENDPOINTS, GONKA_CHAIN_ID
 
+@dataclass
+class Endpoint:
+    """
+    Represents a Gonka endpoint with URL and transfer address.
+    """
+    url: str
+    address: str
+    
+    @classmethod
+    def parse(cls, endpoint_str: str) -> 'Endpoint':
+        """
+        Parse an endpoint string in the format 'url;address'.
+        
+        Args:
+            endpoint_str: String in the format 'url;address'
+            
+        Returns:
+            Endpoint object
+            
+        Raises:
+            ValueError: If no transfer address is provided
+        """
+        parts = endpoint_str.split(';', 1)
+        if len(parts) == 2:
+            url = parts[0].strip()
+            address = parts[1].strip()
+            if not address:
+                raise ValueError("Transfer address is required and cannot be empty")
+            return cls(url=url, address=address)
+        raise ValueError("Endpoint must be in the format 'url;address'")
+
 # Configure logger
 logger = logging.getLogger("gonka")
 logging.basicConfig(level=logging.INFO)
 
-def gonka_base_url(endpoints: Optional[List[str]] = None) -> str:
+def gonka_base_url(endpoints: Optional[List[Union[str, Endpoint]]] = None) -> Endpoint:
     """
     Get a random endpoint from the list of available endpoints.
     
@@ -35,7 +85,10 @@ def gonka_base_url(endpoints: Optional[List[str]] = None) -> str:
         endpoints: Optional list of endpoints to choose from
         
     Returns:
-        A randomly selected endpoint
+        A randomly selected Endpoint object
+        
+    Raises:
+        ValueError: If no valid endpoints with transfer addresses are available
     """
     # Try to get endpoints from arguments, environment, or default to hardcoded values
     endpoint_list = endpoints or []
@@ -43,18 +96,34 @@ def gonka_base_url(endpoints: Optional[List[str]] = None) -> str:
     if not endpoint_list:
         env_endpoints = os.environ.get(ENV.ENDPOINTS)
         if env_endpoints:
-            endpoint_list = [e.strip() for e in env_endpoints.split(',')]
+            # Parse endpoints from environment variable
+            endpoint_list = [Endpoint.parse(e.strip()) for e in env_endpoints.split(',')]
         else:
-            endpoint_list = DEFAULT_ENDPOINTS
+            # Use default endpoints which must include transfer addresses
+            endpoint_list = [Endpoint.parse(endpoint) for endpoint in DEFAULT_ENDPOINTS]
+    
+    # Convert any string endpoints to Endpoint objects
+    parsed_endpoints = []
+    for endpoint in endpoint_list:
+        if isinstance(endpoint, str):
+            parsed_endpoints.append(Endpoint.parse(endpoint))
+        else:
+            # Validate that the Endpoint object has a non-empty address
+            if not endpoint.address:
+                raise ValueError(f"Endpoint {endpoint.url} is missing a required transfer address")
+            parsed_endpoints.append(endpoint)
+    
+    if not parsed_endpoints:
+        raise ValueError("No valid endpoints with transfer addresses are available")
     
     # Select a random endpoint
-    return random.choice(endpoint_list)
+    return random.choice(parsed_endpoints)
 
 
 def custom_endpoint_selection(
-    endpoint_selection_strategy: Callable[[List[str]], str],
-    endpoints: Optional[List[str]] = None
-) -> str:
+    endpoint_selection_strategy: Callable[[List[Endpoint]], Endpoint],
+    endpoints: Optional[List[Union[str, Endpoint]]] = None
+) -> Endpoint:
     """
     Custom endpoint selection strategy.
     
@@ -63,7 +132,10 @@ def custom_endpoint_selection(
         endpoints: Optional list of endpoints to choose from
         
     Returns:
-        The selected endpoint
+        The selected Endpoint object
+        
+    Raises:
+        ValueError: If no valid endpoints with transfer addresses are available
     """
     # Get the list of endpoints
     endpoint_list = endpoints or []
@@ -71,25 +143,50 @@ def custom_endpoint_selection(
     if not endpoint_list:
         env_endpoints = os.environ.get(ENV.ENDPOINTS)
         if env_endpoints:
-            endpoint_list = [e.strip() for e in env_endpoints.split(',')]
+            # Parse endpoints from environment variable
+            endpoint_list = [Endpoint.parse(e.strip()) for e in env_endpoints.split(',')]
         else:
-            endpoint_list = DEFAULT_ENDPOINTS
+            # Use default endpoints which must include transfer addresses
+            endpoint_list = [Endpoint.parse(endpoint) for endpoint in DEFAULT_ENDPOINTS]
+    
+    # Convert any string endpoints to Endpoint objects
+    parsed_endpoints = []
+    for endpoint in endpoint_list:
+        if isinstance(endpoint, str):
+            parsed_endpoints.append(Endpoint.parse(endpoint))
+        else:
+            # Validate that the Endpoint object has a non-empty address
+            if not endpoint.address:
+                raise ValueError(f"Endpoint {endpoint.url} is missing a required transfer address")
+            parsed_endpoints.append(endpoint)
+    
+    if not parsed_endpoints:
+        raise ValueError("No valid endpoints with transfer addresses are available")
     
     # Use the provided strategy to select an endpoint
-    return endpoint_selection_strategy(endpoint_list)
+    return endpoint_selection_strategy(parsed_endpoints)
 
 
-def gonka_signature(body: Any, private_key_hex: str) -> str:
+def gonka_signature(body: Any, private_key_hex: str, timestamp: int, transfer_address: str) -> str:
     """
     Sign a request body with a private key using ECDSA (secp256k1).
     
     Args:
         body: The request body to sign
         private_key_hex: The private key in hex format (with or without 0x prefix)
+        timestamp: Timestamp in nanoseconds
+        transfer_address: The transfer address to include in the signature
         
     Returns:
         The signature as a base64 string
+        
+    Raises:
+        ValueError: If timestamp is not provided or transfer_address is empty
     """
+    # Validate required parameters
+    if not transfer_address:
+        raise ValueError("Transfer address is required and cannot be empty")
+    
     # Remove 0x prefix if present
     private_key_clean = private_key_hex[2:] if private_key_hex.startswith('0x') else private_key_hex
     
@@ -108,13 +205,18 @@ def gonka_signature(body: Any, private_key_hex: str) -> str:
     
     # Convert body to bytes if it's not already
     if isinstance(body, dict):
-        message_bytes = json.dumps(body).encode('utf-8')
+        payload_bytes = json.dumps(body).encode('utf-8')
     elif isinstance(body, str):
-        message_bytes = body.encode('utf-8')
+        payload_bytes = body.encode('utf-8')
     elif isinstance(body, bytes):
-        message_bytes = body
+        payload_bytes = body
     else:
         raise TypeError(f"Unsupported body type: {type(body)}. Must be dict, str, or bytes.")
+    
+    # Create message payload by concatenating components as described in the issue
+    message_bytes = payload_bytes
+    message_bytes += str(timestamp).encode('utf-8')
+    message_bytes += transfer_address.encode('utf-8')
     
     # Sign the message with deterministic ECDSA using our custom encoder
     signature = signing_key.sign_deterministic(
@@ -175,6 +277,7 @@ def gonka_http_client(
     private_key: str,
     address: Optional[str] = None,
     http_client: Optional[httpx.Client] = None,
+    transfer_address: Optional[str] = None,
 ) -> httpx.Client:
     """
     Create a custom HTTP client for OpenAI that signs requests with your private key.
@@ -183,9 +286,13 @@ def gonka_http_client(
         private_key: ECDSA private key for signing requests
         address: Optional Cosmos address to use instead of deriving from private key
         http_client: Optional base HTTP client
+        transfer_address: Optional transfer address for signing requests
         
     Returns:
         A custom HTTP client compatible with the OpenAI client
+        
+    Raises:
+        ValueError: If private key is not provided or if no valid transfer address is available
     """
     
     # Use provided private key or fail
@@ -198,6 +305,16 @@ def gonka_http_client(
     # Derive address if not provided
     resolved_address = address or gonka_address(private_key)
     
+    # Get the endpoint with transfer address
+    endpoint = gonka_base_url()
+    
+    # Use provided transfer address or get it from the endpoint
+    resolved_transfer_address = transfer_address or endpoint.address
+    
+    # Validate that we have a transfer address
+    if not resolved_transfer_address:
+        raise ValueError("Transfer address is required and must be provided either directly or through an endpoint")
+    
     # Wrap the send method to add headers
     original_send = client.send
     
@@ -209,10 +326,22 @@ def gonka_http_client(
         if request.headers is None:
             request.headers = {}
         
+        # Generate unique and accurate timestamp in nanoseconds
+        timestamp = hybrid_timestamp_ns()
+        
         # Add X-Requester-Address header
         request.headers['X-Requester-Address'] = resolved_address
         
-        signature = gonka_signature(request.content, private_key)
+        # Add X-Timestamp header
+        request.headers['X-Timestamp'] = str(timestamp)
+        
+        # Sign the request with timestamp and transfer address
+        signature = gonka_signature(
+            request.content, 
+            private_key, 
+            timestamp, 
+            resolved_transfer_address
+        )
         request.headers['Authorization'] = signature
 
         response = original_send(request, *args, **kwargs)
@@ -221,4 +350,4 @@ def gonka_http_client(
     # Replace the client's send method with the wrapped version
     client.send = wrapped_send
     
-    return client 
+    return client

--- a/python/test.py
+++ b/python/test.py
@@ -8,6 +8,8 @@ import json
 import unittest.mock
 from dotenv import load_dotenv
 
+from src.utils import get_endpoints_from_env_or_default
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -30,6 +32,8 @@ if missing_env_vars:
 
 # If GONKA_ENDPOINTS is set, we'll use real endpoints and real requests
 USE_REAL_REQUESTS = bool(os.environ.get('GONKA_ENDPOINTS'))
+
+default_model = "unsloth/llama-3-8b-Instruct"
 
 def run_tests():
     """Run the tests for the GonkaOpenAI library."""
@@ -64,6 +68,7 @@ def run_tests():
             api_key="mock-api-key",
             gonka_private_key=os.environ.get('GONKA_PRIVATE_KEY'),
             http_client=test_client,
+            endpoints=get_endpoints_from_env_or_default()
         )
         
         print(f"Gonka Address: {gonka_client.gonka_address}")
@@ -71,7 +76,7 @@ def run_tests():
         # Make a chat completion request
         print("\nSending first request...")
         chat_response = gonka_client.chat.completions.create(
-            model="Qwen/QwQ-32B",
+            model=default_model,
             messages=[{"role": "user", "content": "Hello! Tell me a short joke."}],
         )
         
@@ -84,20 +89,21 @@ def run_tests():
         # Create a custom HTTP client for the OpenAI client
         http_client = gonka_http_client(
             private_key=os.environ.get('GONKA_PRIVATE_KEY'),
-            http_client=test_client
+            http_client=test_client,
+            transfer_address=selected_url.address
         )
         
         # Create a standard OpenAI client with the custom HTTP client
         openai_client = OpenAI(
             api_key="mock-api-key",
-            base_url=selected_url,
+            base_url=selected_url.url,
             http_client=http_client
         )
         
         # Make a request with the standard client
         print("\nSending request with standard client + custom HTTP client...")
         standard_response = openai_client.chat.completions.create(
-            model="Qwen/QwQ-32B",
+            model=default_model,
             messages=[{"role": "user", "content": "What is the capital of France?"}],
         )
         
@@ -119,7 +125,7 @@ mock_response_data = {
     "id": "mock-completion-id",
     "object": "chat.completion",
     "created": 1683720588,
-    "model": "Qwen/QwQ-32B",
+    "model": default_model,
     "choices": [
         {
             "message": {

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -20,7 +20,12 @@ import { GonkaOpenAI } from 'gonka-openai';
 // Private key can be provided directly or through environment variable GONKA_PRIVATE_KEY
 const client = new GonkaOpenAI({
   gonkaPrivateKey: '0x1234...', // ECDSA private key for signing requests
-  endpoints: ['https://gonka1.example.com/v1'], // Gonka endpoints
+  endpoints: [
+    {
+      url: 'https://gonka1.example.com/v1',
+      transferAddress: 'gonka1...' // Cosmos address of the endpoint provider
+    }
+  ], // Gonka endpoints with transfer addresses
   // Optional parameters:
   // gonkaAddress: 'cosmos1...', // Override derived Cosmos address
 });
@@ -43,10 +48,18 @@ const fetch = gonkaFetch({
   gonkaPrivateKey: '0x1234...' // Your private key
 });
 
+// Define endpoints with transfer addresses
+const endpoints = [
+  {
+    url: 'https://gonka1.example.com/v1',
+    transferAddress: 'gonka1...' // Cosmos address of the endpoint provider
+  }
+];
+
 // Create an OpenAI client with the custom fetch function
 const client = new OpenAI({
   apiKey: 'mock-api-key', // OpenAI requires any key
-  baseURL: gonkaBaseURL(endpoints: ['https://gonka1.example.com/v1']), // Use Gonka network endpoints 
+  baseURL: gonkaBaseURL(endpoints).url, // Use Gonka network endpoints 
   fetch: fetch // Use the custom fetch function that signs requests
 });
 
@@ -64,7 +77,7 @@ This approach provides the same dynamic request signing as Option 1, but gives y
 Instead of passing configuration directly, you can use environment variables:
 
 - `GONKA_PRIVATE_KEY`: Your ECDSA private key for signing requests
-- `GONKA_ENDPOINTS`: (Optional) Comma-separated list of Gonka network endpoints
+- `GONKA_ENDPOINTS`: (Optional) Comma-separated list of Gonka network endpoints with their transfer addresses. Each endpoint is specified as `url;transferAddress` (semicolon-separated pair).
 - `GONKA_ADDRESS`: (Optional) Override the derived Cosmos address
 
 Example with environment variables:
@@ -72,7 +85,7 @@ Example with environment variables:
 ```typescript
 // Set in your environment:
 // GONKA_PRIVATE_KEY=0x1234...
-// GONKA_ENDPOINTS=https://gonka1.example.com/v1,https://gonka2.example.com/v1
+// GONKA_ENDPOINTS=https://gonka1.example.com/v1;gonka1address1,https://gonka2.example.com/v1;gonka1address2
 
 import { GonkaOpenAI } from 'gonka-openai';
 
@@ -100,11 +113,42 @@ import { GonkaOpenAI } from 'gonka-openai';
 const client = new GonkaOpenAI({
   apiKey: 'mock-api-key',
   gonkaPrivateKey: '0x1234...',
+  endpoints: [
+    {
+      url: 'https://gonka1.example.com/v1',
+      transferAddress: 'gonka1address1'
+    },
+    {
+      url: 'https://gonka2.example.com/v1',
+      transferAddress: 'gonka1address2'
+    }
+  ],
   endpointSelectionStrategy: (endpoints) => {
     // Custom selection logic
+    // Each endpoint has url and transferAddress properties
+    console.log(`Selecting from ${endpoints.length} endpoints`);
     return endpoints[0]; // Always use the first endpoint
   }
 });
+```
+
+## TransferAddress Requirement
+
+Each endpoint in the Gonka network requires a **TransferAddress**, which is the Cosmos address of the endpoint provider. This address is essential for the request signing process and cannot be omitted.
+
+- The TransferAddress is used as part of the signature payload, along with the request body and a timestamp
+- It identifies the provider of the endpoint you're connecting to
+- Without a valid TransferAddress, requests will fail
+
+When specifying endpoints, always include both the URL and the TransferAddress:
+
+```typescript
+const endpoints = [
+  {
+    url: 'https://gonka1.example.com/v1',
+    transferAddress: 'gonka1...' // Cosmos address of the endpoint provider
+  }
+];
 ```
 
 ## How It Works
@@ -112,8 +156,11 @@ const client = new GonkaOpenAI({
 1. **Custom Fetch Implementation**: The library intercepts all outgoing API requests by providing a custom `fetch` implementation to the OpenAI client
 2. **Request Body Signing**: For each request, the library:
    - Extracts the request body
-   - Signs it with your private key using ECDSA
+   - Generates a unique timestamp in nanoseconds
+   - Concatenates the request body, timestamp, and TransferAddress
+   - Signs the combined data with your private key using ECDSA
    - Adds the signature to the `Authorization` header
+   - Adds the timestamp to the `X-Timestamp` header
 3. **Address Generation**: Your Cosmos address (derived from your private key) is added to the `X-Requester-Address` header
 4. **Endpoint Selection**: Requests are routed to the Gonka network using a randomly selected endpoint
 

--- a/typescript/src/constants.ts
+++ b/typescript/src/constants.ts
@@ -1,11 +1,23 @@
+import { GonkaEndpoint } from './types.js';
+
 /**
  * Default Gonka network endpoints
  * These will be used if no endpoints are provided in the options or environment
+ * Each endpoint includes both a URL and a TransferAddress (Cosmos address of the provider)
  */
-export const DEFAULT_ENDPOINTS = [
-  'https://api.gonka.testnet.example.com',
-  'https://api2.gonka.testnet.example.com',
-  'https://api3.gonka.testnet.example.com',
+export const DEFAULT_ENDPOINTS: GonkaEndpoint[] = [
+  {
+    url: 'https://api.gonka.testnet.example.com',
+    transferAddress: 'gonka1example1address1111111111111111111111'
+  },
+  {
+    url: 'https://api2.gonka.testnet.example.com',
+    transferAddress: 'gonka1example2address2222222222222222222222'
+  },
+  {
+    url: 'https://api3.gonka.testnet.example.com',
+    transferAddress: 'gonka1example3address3333333333333333333333'
+  },
 ];
 
 /**

--- a/typescript/src/gonkaOpenAI.ts
+++ b/typescript/src/gonkaOpenAI.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
-import { GonkaOpenAIOptions } from './types.js';
-import { customEndpointSelection, gonkaBaseURL, gonkaFetch } from './utils.js';
+import { GonkaOpenAIOptions, SignatureComponents } from './types.js';
+import { customEndpointSelection, gonkaBaseURL, gonkaFetch, getNanoTimestamp } from './utils.js';
 import { gonkaSignature as signatureFunction } from './utils.js';
 import { ENV } from './constants.js';
 
@@ -10,29 +10,33 @@ import { ENV } from './constants.js';
 export class GonkaOpenAI extends OpenAI {
   private readonly _privateKey: string;
   
+  // Store the selected endpoint
+  private readonly _selectedEndpoint;
+  
   /**
    * Create a new GonkaOpenAI client
    * 
    * @param options Options for the client
    */
   constructor(options: GonkaOpenAIOptions) {
+    console.log('GonkaOpenAI constructor')
     // Get private key from options or environment
     const privateKey = options.gonkaPrivateKey || process.env[ENV.PRIVATE_KEY];
     if (!privateKey) {
       throw new Error(`Private key must be provided either in options or through ${ENV.PRIVATE_KEY} environment variable`);
     }
 
-    // Determine the base URL
-    let baseURL: string;
+    // Determine the endpoint
+    let selectedEndpoint;
     if (options.endpointSelectionStrategy) {
       // Use custom endpoint selection strategy if provided
-      baseURL = customEndpointSelection(options.endpointSelectionStrategy, options.endpoints);
+      selectedEndpoint = customEndpointSelection(options.endpointSelectionStrategy, options.endpoints);
     } else {
       // Default to random endpoint selection
-      baseURL = gonkaBaseURL(options.endpoints);
+      selectedEndpoint = gonkaBaseURL(options.endpoints);
     }
 
-    // Create the signing fetch function directly (now that it's synchronous)
+    // Create the signing fetch function
     const signingFetch = gonkaFetch({
       gonkaPrivateKey: privateKey,
       gonkaAddress: options.gonkaAddress || process.env[ENV.ADDRESS]
@@ -41,7 +45,7 @@ export class GonkaOpenAI extends OpenAI {
     // Create the OpenAI configuration object
     const openAIConfig = {
       ...options,
-      baseURL,
+      baseURL: selectedEndpoint.url,
     };
     
     // Set default mock-api-key if no apiKey is provided
@@ -55,8 +59,9 @@ export class GonkaOpenAI extends OpenAI {
     // Call OpenAI constructor with the configuration
     super(openAIConfig);
     
-    // Save the private key for signing requests
+    // Save the private key and selected endpoint for signing requests
     this._privateKey = privateKey;
+    this._selectedEndpoint = selectedEndpoint;
   }
   
   /**
@@ -65,14 +70,35 @@ export class GonkaOpenAI extends OpenAI {
   get privateKey(): string {
     return this._privateKey;
   }
-  
+
   /**
    * Sign a request body with the client's private key
    * 
    * @param body The request body to sign
+   * @param transferAddress The Cosmos address of the endpoint provider (optional, uses the selected endpoint's address if not provided)
    * @returns The signature as a base64 string
    */
-  async signRequest(body: any): Promise<string> {
-    return await signatureFunction(body, this._privateKey);
+  async signRequest(body: any, transferAddress?: string): Promise<string> {
+    // Generate a unique timestamp in nanoseconds
+    const timestamp = getNanoTimestamp();
+    
+    // Use the provided transfer address or the selected endpoint's address
+    const address = transferAddress || this._selectedEndpoint.transferAddress;
+    
+    // Create signature components
+    const components: SignatureComponents = {
+      payload: body,
+      timestamp: timestamp,
+      transferAddress: address
+    };
+    
+    return await signatureFunction(components, this._privateKey);
+  }
+  
+  /**
+   * Get the selected endpoint
+   */
+  get selectedEndpoint() {
+    return this._selectedEndpoint;
   }
 } 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,5 +1,5 @@
 // Export main classes and functions
 export { GonkaOpenAI } from './gonkaOpenAI.js';
-export { gonkaBaseURL, gonkaSignature, gonkaAddress, gonkaFetch } from './utils.js';
+export { gonkaBaseURL, gonkaSignature, gonkaAddress, gonkaFetch, getNanoTimestamp, getSigBytes } from './utils.js';
 export { DEFAULT_ENDPOINTS } from './constants.js';
-export type { GonkaOpenAIOptions } from './types.js'; 
+export type { GonkaOpenAIOptions, GonkaEndpoint, SignatureComponents } from './types.js';

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -1,9 +1,24 @@
 import { ClientOptions } from 'openai';
 
 /**
+ * Endpoint object with URL and TransferAddress
+ */
+export interface GonkaEndpoint {
+  /**
+   * URL of the endpoint
+   */
+  url: string;
+  
+  /**
+   * Cosmos address of the endpoint provider
+   */
+  transferAddress: string;
+}
+
+/**
  * Function type for custom endpoint selection
  */
-export type EndpointSelectionFunction = (endpoints: string[]) => string;
+export type EndpointSelectionFunction = (endpoints: GonkaEndpoint[]) => GonkaEndpoint;
 
 /**
  * Options for the GonkaOpenAI client
@@ -26,8 +41,9 @@ export interface GonkaOpenAIOptions extends Omit<ClientOptions, 'baseURL' | 'def
    * List of Gonka network endpoints to use
    * One will be selected randomly for each client instance
    * If not provided, will use DEFAULT_ENDPOINTS or GONKA_ENDPOINTS environment variable
+   * Each endpoint must include both a URL and a TransferAddress (Cosmos address of the provider)
    */
-  endpoints?: string[];
+  endpoints?: GonkaEndpoint[];
 
   /**
    * Custom function for signing request bodies
@@ -46,6 +62,26 @@ export interface GonkaOpenAIOptions extends Omit<ClientOptions, 'baseURL' | 'def
 export type OpenAIFetch = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 /**
+ * Components required for signature generation
+ */
+export interface SignatureComponents {
+  /**
+   * The payload to sign
+   */
+  payload: any;
+  
+  /**
+   * Timestamp in nanoseconds
+   */
+  timestamp: bigint;
+  
+  /**
+   * Cosmos address of the endpoint provider
+   */
+  transferAddress: string;
+}
+
+/**
  * Function to sign request body with private key
  */
-export type SignatureFunction = (body: any, privateKey: string) => string | Promise<string>; 
+export type SignatureFunction = (components: SignatureComponents, privateKey: string) => string | Promise<string>; 

--- a/typescript/src/utils.ts
+++ b/typescript/src/utils.ts
@@ -4,20 +4,35 @@ import secp256k1 from 'secp256k1';
 import { ENV, DEFAULT_ENDPOINTS, GONKA_CHAIN_ID } from './constants.js';
 import { EndpointSelectionFunction } from './types.js';
 
+import { GonkaEndpoint } from './types.js';
+
 /**
  * Get a random endpoint from the list of available endpoints
  * 
  * @param endpoints Optional list of endpoints to choose from
  * @returns A randomly selected endpoint
  */
-export const gonkaBaseURL = (endpoints?: string[]): string => {
+export const gonkaBaseURL = (endpoints?: GonkaEndpoint[]): GonkaEndpoint => {
   // Try to get endpoints from arguments, environment, or default to hardcoded values
   let endpointList = endpoints || [];
   
   if (endpointList.length === 0) {
     const envEndpoints = process.env[ENV.ENDPOINTS];
     if (envEndpoints) {
-      endpointList = envEndpoints.split(',').map((e: string) => e.trim());
+      // Parse semicolon-separated pairs of URL and address
+      endpointList = envEndpoints.split(',').map((e: string) => {
+        const parts = e.trim().split(';');
+        if (parts.length !== 2) {
+          throw new Error(`Invalid endpoint format: ${e}. Expected format: "url;transferAddress"`);
+        }
+
+        console.log(`URL: ${parts[0]}, Address: ${parts[1]}`);
+
+        return {
+          url: parts[0],
+          transferAddress: parts[1]
+        };
+      });
     } else {
       endpointList = DEFAULT_ENDPOINTS;
     }
@@ -37,15 +52,25 @@ export const gonkaBaseURL = (endpoints?: string[]): string => {
  */
 export const customEndpointSelection = (
   endpointSelectionStrategy: EndpointSelectionFunction,
-  endpoints?: string[]
-): string => {
+  endpoints?: GonkaEndpoint[]
+): GonkaEndpoint => {
   // Get the list of endpoints
   let endpointList = endpoints || [];
   
   if (endpointList.length === 0) {
     const envEndpoints = process.env[ENV.ENDPOINTS];
     if (envEndpoints) {
-      endpointList = envEndpoints.split(',').map((e: string) => e.trim());
+      // Parse semicolon-separated pairs of URL and address
+      endpointList = envEndpoints.split(',').map((e: string) => {
+        const parts = e.trim().split(';');
+        if (parts.length !== 2) {
+          throw new Error(`Invalid endpoint format: ${e}. Expected format: "url;transferAddress"`);
+        }
+        return {
+          url: parts[0],
+          transferAddress: parts[1]
+        };
+      });
     } else {
       endpointList = DEFAULT_ENDPOINTS;
     }
@@ -55,14 +80,74 @@ export const customEndpointSelection = (
   return endpointSelectionStrategy(endpointList);
 };
 
+import { SignatureComponents } from './types.js';
+
+/**
+ * Get the bytes to sign from the signature components
+ * 
+ * @param components The signature components
+ * @returns The bytes to sign
+ */
+export const getSigBytes = (components: SignatureComponents): Uint8Array => {
+  // Convert payload to bytes if needed
+  let payloadBytes;
+  if (typeof components.payload === 'string') {
+    payloadBytes = Buffer.from(components.payload);
+  } else if (Buffer.isBuffer(components.payload)) {
+    payloadBytes = components.payload;
+  } else if (components.payload instanceof Uint8Array) {
+    payloadBytes = Buffer.from(components.payload);
+  } else {
+    // For objects or other types, stringify and convert to bytes
+    payloadBytes = Buffer.from(JSON.stringify(components.payload));
+  }
+  
+  // Convert timestamp to string and then to bytes
+  const timestampBytes = Buffer.from(components.timestamp.toString());
+  
+  // Convert transfer address to bytes
+  const transferAddressBytes = Buffer.from(components.transferAddress);
+  
+  // Concatenate all bytes
+  const messageBytes = Buffer.concat([
+    payloadBytes,
+    timestampBytes,
+    transferAddressBytes
+  ]);
+  
+  return messageBytes;
+};
+
+/**
+ * Get current timestamp in nanoseconds
+ * 
+ * @returns Current timestamp in nanoseconds as a bigint
+ */
+/**
+ * Get current timestamp in nanoseconds since Unix epoch
+ *
+ * @returns Current timestamp in nanoseconds since Unix epoch
+ */
+export const getNanoTimestamp = (): bigint => {
+  // Get milliseconds since epoch and convert to nanoseconds
+  const millisSinceEpoch = BigInt(Date.now());
+  const nanosSinceEpoch = millisSinceEpoch * 1000000n;
+
+  // Add high-resolution nanoseconds for sub-millisecond precision
+  const hrTime = process.hrtime();
+  const subMillisecondNanos = BigInt(hrTime[1] % 1000000);
+
+  return nanosSinceEpoch + subMillisecondNanos;
+};
+
 /**
  * Sign a request body with a private key using ECDSA
  * 
- * @param body The request body to sign
+ * @param components The signature components (payload, timestamp, transferAddress)
  * @param privateKeyHex The private key in hex format (with or without 0x prefix)
  * @returns The signature as a base64 string
  */
-export const gonkaSignature = async (body: any, privateKeyHex: string): Promise<string> => {
+export const gonkaSignature = async (components: SignatureComponents, privateKeyHex: string): Promise<string> => {
   // Remove 0x prefix if present
   const privateKeyClean = privateKeyHex.startsWith('0x') ? privateKeyHex.slice(2) : privateKeyHex;
   
@@ -71,18 +156,8 @@ export const gonkaSignature = async (body: any, privateKeyHex: string): Promise<
     privateKeyClean.match(/.{1,2}/g)?.map(byte => parseInt(byte, 16)) || []
   );
 
-  // Convert body to bytes if needed
-  let messageBytes;
-  if (typeof body === 'string') {
-    messageBytes = Buffer.from(body);
-  } else if (Buffer.isBuffer(body)) {
-    messageBytes = body;
-  } else if (body instanceof Uint8Array) {
-    messageBytes = Buffer.from(body);
-  } else {
-    // For objects or other types, stringify and convert to bytes
-    messageBytes = Buffer.from(JSON.stringify(body));
-  }
+  // Get the bytes to sign
+  const messageBytes = getSigBytes(components);
   
   // Hash the payload with SHA-256 using Node.js crypto
   const messageHash = sha256(messageBytes);
@@ -165,11 +240,65 @@ export const gonkaFetch = (
       requestInit.headers.set('X-Requester-Address', address);
     }
     
+    // Get the URL string from the URL object
+    const urlString = url instanceof URL ? url.toString() : url.toString();
+    
+    // Extract the endpoint from the URL
+    let selectedEndpoint: GonkaEndpoint | undefined;
+    
+    // Try to find the endpoint in the DEFAULT_ENDPOINTS
+    for (const endpoint of DEFAULT_ENDPOINTS) {
+      if (urlString.startsWith(endpoint.url)) {
+        selectedEndpoint = endpoint;
+        break;
+      }
+    }
+    
+    // If endpoint not found in DEFAULT_ENDPOINTS, try to parse from environment
+    let endpoints = process.env[ENV.ENDPOINTS];
+    if (!selectedEndpoint && endpoints) {
+      const envEndpoints = endpoints.split(',').map((e: string) => {
+        const parts = e.trim().split(';');
+        if (parts.length !== 2) {
+          return null;
+        }
+        return {
+          url: parts[0],
+          transferAddress: parts[1]
+        };
+      }).filter(Boolean) as GonkaEndpoint[];
+      
+      for (const endpoint of envEndpoints) {
+        if (urlString.startsWith(endpoint.url)) {
+          selectedEndpoint = endpoint;
+          break;
+        }
+      }
+    }
+    
+    // If no endpoint found, throw an error
+    if (!selectedEndpoint) {
+      throw new Error(`Could not determine the endpoint for URL: ${urlString}`);
+    }
+    
+    // Generate a unique timestamp in nanoseconds
+    const timestamp = getNanoTimestamp();
+    console.log('Timestampn:', timestamp);
+    // Add the X-Timestamp header
+    requestInit.headers.set('X-Timestamp', timestamp.toString());
+    
     // If there's a body, sign it and add the signature to the Authorization header
     if (requestInit.body) {
-      try {        
-        // Sign the body
-        const signature = await gonkaSignature(requestInit.body, privateKey);
+      try {
+        // Create signature components
+        const components: SignatureComponents = {
+          payload: requestInit.body,
+          timestamp: timestamp,
+          transferAddress: selectedEndpoint.transferAddress
+        };
+        
+        // Sign the components
+        const signature = await gonkaSignature(components, privateKey);
         
         // Add the signature to the Authorization header
         requestInit.headers.set('Authorization', signature);
@@ -186,4 +315,4 @@ export const gonkaFetch = (
     // Call the original fetch with the modified request
     return originalFetch(url, requestInit);
   };
-}; 
+};

--- a/typescript/test.mjs
+++ b/typescript/test.mjs
@@ -3,6 +3,7 @@ import { GonkaOpenAI, gonkaBaseURL, gonkaFetch } from './dist/index.js';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
+let defaultModel = 'unsloth/llama-3-8b-Instruct';
 
 // Check for required environment variables
 const requiredEnvVars = ['GONKA_PRIVATE_KEY'];
@@ -67,7 +68,7 @@ if (!USE_REAL_REQUESTS) {
         id: 'mock-completion-id',
         object: 'chat.completion',
         created: Date.now(),
-        model: 'Qwen/QwQ-32B',
+        model: defaultModel,
         choices: [
           {
             message: {
@@ -86,8 +87,11 @@ if (!USE_REAL_REQUESTS) {
 const run = async () => {
   try {
     console.log('\n------ Test Environment ------');
-    const baseUrl = gonkaBaseURL();
-    console.log('Using Gonka Base URL:', baseUrl);
+    const selectedEndpoint = gonkaBaseURL();
+    console.log('Using Gonka Endpoint:', {
+      url: selectedEndpoint.url,
+      transferAddress: selectedEndpoint.transferAddress
+    });
     
     if (USE_REAL_REQUESTS) {
       console.log("Using REAL HTTP requests - this will make actual API calls!");
@@ -105,7 +109,7 @@ const run = async () => {
     // Make a chat completion request
     console.log('\nSending first request...');
     const chatResponse = await gonkaClient.chat.completions.create({
-      model: 'Qwen/QwQ-32B',
+      model: defaultModel,
       messages: [{ role: 'user', content: 'Hello! Tell me a short joke.' }],
     });
     
@@ -123,14 +127,14 @@ const run = async () => {
     // Create a standard OpenAI client with our custom fetch
     const openaiClient = new OpenAI({
       apiKey: 'mock-api-key', // This can be any string when using Gonka
-      baseURL: baseUrl,
+      baseURL: selectedEndpoint.url, // Use the URL property from the endpoint
       fetch: customFetch
     });
     
     // Make a request with the standard client (will be signed by our custom fetch)
     console.log('\nSending request with standard client + custom fetch...');
     const standardResponse = await openaiClient.chat.completions.create({
-      model: 'Qwen/QwQ-32B',
+      model: defaultModel,
       messages: [{ role: 'user', content: 'What is the capital of France?' }],
     });
     


### PR DESCRIPTION
Add logic for signing payloads with higher security. Append:
1. The bytes of the payload
2. The bytes of a generated timestamp in Nanos (should be unique)
3. The bytes of the ADDRESS of the participant running the endpoint the request is sent to.
Then the concatenated string is signed using the private key, as before.
The timestamp needs to be within 60 seconds of the chain time or it will be rejected.

All of the APIs have been updated to take "Endpoint" instead of url as string. The Endpoint take a url and the address (often referred to as the transfer address)

When used with ENV variables, the two are represented as single semicolon delimited string. (https://api.gonka.com/v1;gonka1393949jabcd78093efda).